### PR TITLE
:bug: change com.reactlibrary to avoid conflict with other libs

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.reactlibrary">
+          package="com.react-native-pinning-ssl">
 
 </manifest>
   


### PR DESCRIPTION
I've had some problems with other libs which uses a default package name.

this should fix the isse